### PR TITLE
New Query Param on getFile to Return AVIF File Type

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -14,10 +14,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: '1.22'
 

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -5,7 +5,7 @@ name: Go
 
 on:
   push:
-    branches: [ "main", "5-setup-github-actions", "dev" ]
+    branches: [ "main", "10-serve-images-avif-format", "dev" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Set up AVIF dependency
+      run: sudo apt-get install -y libaom-dev
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -5,7 +5,7 @@ name: Go
 
 on:
   push:
-    branches: [ "main", "10-serve-images-avif-format", "dev" ]
+    branches: [ "main", "dev" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,10 @@
 go.work
 
 # Misc files that may be present locally
+*.avif
 *.jpg
 *.jpeg
 *.png
 *.json
 main
+uploads/

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22
 require github.com/labstack/echo/v4 v4.11.4
 
 require (
+	github.com/Kagami/go-avif v0.1.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Kagami/go-avif v0.1.0 h1:8GHAGLxCdFfhpd4Zg8j1EqO7rtcQNenxIDerC/uu68w=
+github.com/Kagami/go-avif v0.1.0/go.mod h1:OPmPqzNdQq3+sXm0HqaUJQ9W/4k+Elbc3RSfJUemDKA=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=

--- a/main.go
+++ b/main.go
@@ -151,31 +151,39 @@ func updateFileTags(c echo.Context) error {
 
 // e.GET("/file/:name", getFile)
 func getFile(c echo.Context) error {
-	// name string will be urlencoded
 	encodedName := c.Param("name")
-	// decode the name
 	name, err := url.QueryUnescape(encodedName)
 	if err != nil {
 		return err
 	}
-	// return c.File(fmt.Sprintf("/opt/picloud/uploads/%s", name))
-	return c.File(fmt.Sprintf("%s%s", FilePrefix, name))
+
+	avifFmt := c.QueryParam("avif")
+	if avifFmt == "true" {
+		return getAvif(c)
+	} else {
+		return c.File(fmt.Sprintf("%s%s", FilePrefix, name))
+	}
 }
 
-// TODO: Implement fileType as query parameter on getFile operation to replace the getAvif func
-// e.GET("/file/:name/avif", getAvif)
 func getAvif(c echo.Context) error {
 	encodedName := c.Param("name")
 	name, err := url.QueryUnescape(encodedName)
 	if err != nil {
 		return err
 	}
-	// check if the file exists
+
+	// check if avif file already exists and return it if it does
+	if _, err := os.Stat(fmt.Sprintf("%s%s.avif", FilePrefix, name)); err == nil {
+		slog.Info("Found existing AVIF file")
+		return c.File(fmt.Sprintf("%s%s.avif", FilePrefix, name))
+	}
+
+	// check if the src file exists
 	if _, err := os.Stat(fmt.Sprintf("%s%s", FilePrefix, name)); err != nil {
 		slog.Info("File not found")
 		return c.String(http.StatusNotFound, "File not found")
 	}
-	slog.Info("File found")
+	slog.Info("Src file found")
 
 	// open the srcFile
 	srcFile, err := os.Open(fmt.Sprintf("%s%s", FilePrefix, name))
@@ -185,14 +193,12 @@ func getAvif(c echo.Context) error {
 	slog.Info("File opened")
 	defer srcFile.Close()
 
-	// TODO: Check if AVIF file already exists before creating a new one
-
 	// create new avif file
 	dstFile, err := os.Create(fmt.Sprintf("%s%s.avif", FilePrefix, name))
 	if err != nil {
 		return err
 	}
-	slog.Debug("dstFile created")
+	slog.Debug(fmt.Sprintf("Created file %s%s.avif", FilePrefix, name))
 
 	// decode the src file
 	img, err := jpeg.Decode(srcFile)
@@ -273,7 +279,6 @@ func main() {
 	})
 	e.GET("/file/:name", getFile)
 	e.PATCH("/file/:name", updateFileTags)
-	e.GET("/file/:name/avif", getAvif)
 	e.POST("/file/upload", saveFile)
 	e.GET("/files", listFiles)
 	e.GET("/files/search", searchFiles)

--- a/main.go
+++ b/main.go
@@ -38,8 +38,8 @@ type UploadedFiles struct {
 	Files []FileMetadata `json:"files"`
 }
 
-// const FilePrefix = "/opt/picloud/uploads/"
-const FilePrefix = "uploads/" // localhost
+const FilePrefix = "/opt/picloud/uploads/"
+// const FilePrefix = "uploads/" // localhost
 
 // global var initialized before API to store info on the server's uploaded files
 var uploadedFiles UploadedFiles


### PR DESCRIPTION
## Changes

- New function `getAvif` to convert existing images (jpeg) to AVIF format
- Added query param `avif` to GET /file/:name operation

## To Do

- [x] Add query parameter to existing `getFile` function
- [x] Check if AVIF file exists before creating new one