### PR TITLE
Feat/13 create alt sizes for uploaded files

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,9 +38,9 @@ type UploadedFiles struct {
 	Files []FileMetadata `json:"files"`
 }
 
-const FilePrefix = "/opt/picloud/uploads/"
+// const FilePrefix = "/opt/picloud/uploads/"
 
-// const FilePrefix = "uploads/" // localhost
+const FilePrefix = "uploads/" // localhost
 
 // global var initialized before API to store info on the server's uploaded files
 var uploadedFiles UploadedFiles
@@ -166,6 +166,10 @@ func getFile(c echo.Context) error {
 	if avifFmt == "true" {
 		return getAvif(c)
 	} else {
+		err := createIconSize(fmt.Sprintf("%s%s", FilePrefix, name))
+		if err != nil {
+			return err
+		}
 		return c.File(fmt.Sprintf("%s%s", FilePrefix, name))
 	}
 }

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ type UploadedFiles struct {
 }
 
 const FilePrefix = "/opt/picloud/uploads/"
+
 // const FilePrefix = "uploads/" // localhost
 
 // global var initialized before API to store info on the server's uploaded files

--- a/main.go
+++ b/main.go
@@ -83,6 +83,12 @@ func writeFileMetadata() {
 	}
 }
 
+func createAltSizes(filename string) {
+	// load original file data based on filename
+	// create alt sizes - thumbnail/icon size and medium size
+	slog.Info(fmt.Sprintf("Creating alt sizes for %s", filename))
+}
+
 // buildLink returns a link to be used in the FileMetadata struct on initialization
 func buildLink(rawFilename string) string {
 	return fmt.Sprintf("http://pi.local:1234/file/%s", url.QueryEscape(rawFilename))
@@ -121,6 +127,7 @@ func saveFile(c echo.Context) error {
 	tags := form.Value["tags"]
 	uploadedFiles.Files = append(uploadedFiles.Files, FileMetadata{Name: file.Filename, Tags: tags, Link: buildLink(file.Filename)})
 	go writeFileMetadata()
+	go createAltSizes(file.Filename)
 	return c.String(http.StatusOK, fmt.Sprintf("File %s uploaded successfully!", file.Filename))
 }
 

--- a/main.go
+++ b/main.go
@@ -47,7 +47,6 @@ var uploadedFiles UploadedFiles
 
 func loadFileMetadata() UploadedFiles {
 	var files UploadedFiles
-	// check if file exists
 	if _, err := os.Stat("metadata.json"); err == nil {
 		data, err := os.ReadFile("metadata.json")
 		if err != nil {
@@ -72,7 +71,6 @@ func loadFileMetadata() UploadedFiles {
 }
 
 func writeFileMetadata() {
-	// write file metadata to file
 	data, err := json.Marshal(uploadedFiles)
 	if err != nil {
 		panic(err)
@@ -89,7 +87,6 @@ func createAltSizes(filename string) {
 	slog.Info(fmt.Sprintf("Creating alt sizes for %s", filename))
 }
 
-// buildLink returns a link to be used in the FileMetadata struct on initialization
 func buildLink(rawFilename string) string {
 	return fmt.Sprintf("http://pi.local:1234/file/%s", url.QueryEscape(rawFilename))
 }
@@ -214,7 +211,6 @@ func getAvif(c echo.Context) error {
 		slog.Error("Error decoding image")
 		return err
 	}
-	slog.Debug("Image decoded successfully")
 
 	// encode the img as avif file
 	err = avif.Encode(dstFile, img, nil)
@@ -230,14 +226,11 @@ func getAvif(c echo.Context) error {
 
 // e.GET("/files", listFiles)
 func listFiles(c echo.Context) error {
-	// list all available files
 	return c.JSON(http.StatusOK, uploadedFiles)
 }
 
 // e.GET("/files/search", searchFiles)
 func searchFiles(c echo.Context) error {
-	// search for files by tag
-	// get the tag from the request
 	tag := c.QueryParam("tag")
 	// search for the tag in the uploadedFiles
 	var foundFiles []FileMetadata

--- a/main.go
+++ b/main.go
@@ -81,12 +81,6 @@ func writeFileMetadata() {
 	}
 }
 
-func createAltSizes(filename string) {
-	// load original file data based on filename
-	// create alt sizes - thumbnail/icon size and medium size
-	slog.Info(fmt.Sprintf("Creating alt sizes for %s", filename))
-}
-
 func buildLink(rawFilename string) string {
 	return fmt.Sprintf("http://pi.local:1234/file/%s", url.QueryEscape(rawFilename))
 }
@@ -166,10 +160,6 @@ func getFile(c echo.Context) error {
 	if avifFmt == "true" {
 		return getAvif(c)
 	} else {
-		err := createIconSize(fmt.Sprintf("%s%s", FilePrefix, name))
-		if err != nil {
-			return err
-		}
 		return c.File(fmt.Sprintf("%s%s", FilePrefix, name))
 	}
 }

--- a/main.go
+++ b/main.go
@@ -38,9 +38,9 @@ type UploadedFiles struct {
 	Files []FileMetadata `json:"files"`
 }
 
-// const FilePrefix = "/opt/picloud/uploads/"
+const FilePrefix = "/opt/picloud/uploads/"
 
-const FilePrefix = "uploads/" // localhost
+// const FilePrefix = "uploads/" // localhost
 
 // global var initialized before API to store info on the server's uploaded files
 var uploadedFiles UploadedFiles

--- a/main.go
+++ b/main.go
@@ -275,6 +275,7 @@ func main() {
 			return nil
 		},
 	}))
+	e.Use(middleware.CORS())
 	e.GET("/", func(c echo.Context) error {
 		return c.String(http.StatusOK, "Hello, World!")
 	})

--- a/resizer.go
+++ b/resizer.go
@@ -17,11 +17,17 @@ func copyImage(img *image.Image) error {
 	defer dstFile.Close()
 
 	// create new image
-	maxX := (*img).Bounds().Dx() / 2
-	maxY := (*img).Bounds().Dy() / 2
+	maxX := (*img).Bounds().Dx()
+	maxY := (*img).Bounds().Dy()
 	// newImg := image.NewRGBA((*img).Bounds())
 	newImg := image.NewRGBA(image.Rect(0, 0, maxX, maxY))
 	fmt.Printf("New image bounds: %v\n", newImg.Bounds())
+
+	for y := range (*img).Bounds().Dy() {
+		for x := range (*img).Bounds().Dx() {
+			newImg.Set(x, y, (*img).At(x, y))
+		}
+	}
 
 	err = jpeg.Encode(dstFile, newImg, nil)
 	if err != nil {

--- a/resizer.go
+++ b/resizer.go
@@ -8,24 +8,24 @@ import (
 	"os"
 )
 
-func copyImage(img *image.Image) error {
+func writeNewImg(img *image.Image, scale int, filename string) error {
 	// create destination file
-	dstFile, err := os.Create("copy-test.jpeg")
+	dstFile, err := os.Create(fmt.Sprintf("%s-%d.jpeg", filename, scale))
 	if err != nil {
 		return err
 	}
 	defer dstFile.Close()
 
 	// create new image
-	maxX := (*img).Bounds().Dx() / 4
-	maxY := (*img).Bounds().Dy() / 4
+	maxX := (*img).Bounds().Dx() / scale
+	maxY := (*img).Bounds().Dy() / scale
 	// newImg := image.NewRGBA((*img).Bounds())
 	newImg := image.NewRGBA(image.Rect(0, 0, maxX, maxY))
 	fmt.Printf("New image bounds: %v\n", newImg.Bounds())
 
 	for y := range (*newImg).Bounds().Dy() {
 		for x := range (*newImg).Bounds().Dx() {
-			newImg.Set(x, y, (*img).At(x*4, y*4))
+			newImg.Set(x, y, (*img).At(x*scale, y*scale))
 		}
 	}
 
@@ -36,27 +36,29 @@ func copyImage(img *image.Image) error {
 	return nil
 }
 
-// Remove the unused function createIconSize
-func createIconSize(srcPath string) error {
-	fmt.Printf("Creating icon size for %s\n", srcPath)
+func createAltSizes(srcPath string) {
+	slog.Info(fmt.Sprintf("Creating alt sizes for %s", srcPath))
 	srcFile, err := os.Open(srcPath)
 	if err != nil {
-		return err
+		panic(err)
 	}
 	defer srcFile.Close()
 
 	img, err := jpeg.Decode(srcFile)
 	if err != nil {
 		slog.Error("Error decoding image")
-		return err
+		panic(err)
 	}
 
-	fmt.Printf("Image bounds: %v\n", img.Bounds())
-	fmt.Printf("Image color model: %s\n", img.ColorModel())
-	fmt.Printf("Image width: %d, height: %d\n", img.Bounds().Dx(), img.Bounds().Dy())
-	err = copyImage(&img)
+	filename := srcFile.Name()
+	// Create medium img at 1/4 size
+	err = writeNewImg(&img, 4, filename)
 	if err != nil {
-		return err
+		panic(err)
 	}
-	return nil
+	// Create icon image at 1/10 size
+	err = writeNewImg(&img, 10, filename)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/resizer.go
+++ b/resizer.go
@@ -1,8 +1,29 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"image/jpeg"
+	"log/slog"
+	"os"
+)
 
 // Remove the unused function createIconSize
-func createIconSize() {
+func createIconSize(srcPath string) error {
 	fmt.Printf("Creating icon size\n")
+	srcFile, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	img, err := jpeg.Decode(srcFile)
+	if err != nil {
+		slog.Error("Error decoding image")
+		return err
+	}
+
+	fmt.Printf("Image bounds: %v\n", img.Bounds())
+	fmt.Printf("Image color model: %v\n", img.ColorModel())
+	fmt.Printf("Image width: %d, height: %d\n", img.Bounds().Dx(), img.Bounds().Dy())
+	return nil
 }

--- a/resizer.go
+++ b/resizer.go
@@ -17,15 +17,15 @@ func copyImage(img *image.Image) error {
 	defer dstFile.Close()
 
 	// create new image
-	maxX := (*img).Bounds().Dx()
-	maxY := (*img).Bounds().Dy()
+	maxX := (*img).Bounds().Dx() / 4
+	maxY := (*img).Bounds().Dy() / 4
 	// newImg := image.NewRGBA((*img).Bounds())
 	newImg := image.NewRGBA(image.Rect(0, 0, maxX, maxY))
 	fmt.Printf("New image bounds: %v\n", newImg.Bounds())
 
-	for y := range (*img).Bounds().Dy() {
-		for x := range (*img).Bounds().Dx() {
-			newImg.Set(x, y, (*img).At(x, y))
+	for y := range (*newImg).Bounds().Dy() {
+		for x := range (*newImg).Bounds().Dx() {
+			newImg.Set(x, y, (*img).At(x*4, y*4))
 		}
 	}
 

--- a/resizer.go
+++ b/resizer.go
@@ -2,14 +2,37 @@ package main
 
 import (
 	"fmt"
+	"image"
 	"image/jpeg"
 	"log/slog"
 	"os"
 )
 
+func copyImage(img *image.Image) error {
+	// create destination file
+	dstFile, err := os.Create("copy-test.jpeg")
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	// create new image
+	maxX := (*img).Bounds().Dx() / 2
+	maxY := (*img).Bounds().Dy() / 2
+	// newImg := image.NewRGBA((*img).Bounds())
+	newImg := image.NewRGBA(image.Rect(0, 0, maxX, maxY))
+	fmt.Printf("New image bounds: %v\n", newImg.Bounds())
+
+	err = jpeg.Encode(dstFile, newImg, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // Remove the unused function createIconSize
 func createIconSize(srcPath string) error {
-	fmt.Printf("Creating icon size\n")
+	fmt.Printf("Creating icon size for %s\n", srcPath)
 	srcFile, err := os.Open(srcPath)
 	if err != nil {
 		return err
@@ -23,7 +46,11 @@ func createIconSize(srcPath string) error {
 	}
 
 	fmt.Printf("Image bounds: %v\n", img.Bounds())
-	fmt.Printf("Image color model: %v\n", img.ColorModel())
+	fmt.Printf("Image color model: %s\n", img.ColorModel())
 	fmt.Printf("Image width: %d, height: %d\n", img.Bounds().Dx(), img.Bounds().Dy())
+	err = copyImage(&img)
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/resizer.go
+++ b/resizer.go
@@ -1,0 +1,8 @@
+package main
+
+import "fmt"
+
+// Remove the unused function createIconSize
+func createIconSize() {
+	fmt.Printf("Creating icon size\n")
+}


### PR DESCRIPTION
### Changes

- New file `resizer.go` containing functions responsible for creating new alt sized images on disk
- At the end of the `saveFile` function in `main.go`, the new function `createAltSizes` is invoked in a goroutine

#### createAltSizes
Decodes the jpeg image and calls `writeNewImg` to create 2 new files at 1/4 and 1/10 scales.

#### writeNewImg
Creates new file on disk at scale specified in input parameter.

### Known Issue
This only works with jpeg files currently. Same with the `getAvif` functionality (#10). Will address in future.